### PR TITLE
feat(cli): inject dynamic version into CLI banner

### DIFF
--- a/clarctl-go/Makefile
+++ b/clarctl-go/Makefile
@@ -1,7 +1,7 @@
 VERSION     ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 BINARY      := clarctl
 MODULE      := github.com/Vaishnav88sk/claritty/clarctl-go
-BUILD_FLAGS := -ldflags="-s -w -X main.Version=$(VERSION)"
+BUILD_FLAGS := -ldflags="-s -w -X github.com/Vaishnav88sk/claritty/clarctl-go/internal/ui.Version=$(VERSION)"
 DIST        := dist
 
 .PHONY: all build install clean test lint cross help

--- a/clarctl-go/internal/ui/ui.go
+++ b/clarctl-go/internal/ui/ui.go
@@ -32,6 +32,10 @@ var (
 			Padding(0, 1)
 )
 
+// Version is the CLI version. It is meant to be overridden at build time via ldflags.
+// Example: go build -ldflags "-X 'github.com/Vaishnav88sk/claritty/clarctl-go/internal/ui.Version=v1.1.0'"
+var Version = "dev"
+
 // PrintBanner renders the Claritty ASCII art banner.
 func PrintBanner() {
 	banner := `
@@ -42,7 +46,7 @@ func PrintBanner() {
 ╚██████╗███████╗██║  ██║██║  ██║██║   ██║      ██║      ██║   
  ╚═════╝╚══════╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝   ╚═╝      ╚═╝      ╚═╝   `
 
-	info := styleDim.Render("AI-SRE Engine  ·  v1.0  ·  Kubernetes Observability")
+	info := styleDim.Render(fmt.Sprintf("AI-SRE Engine  ·  %s  ·  Kubernetes Observability", Version))
 	fmt.Println(styleBanner.Render(banner + "\n" + info))
 	fmt.Println()
 }

--- a/clarctl-go/internal/ui/ui_test.go
+++ b/clarctl-go/internal/ui/ui_test.go
@@ -1,0 +1,47 @@
+package ui
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPrintBanner(t *testing.T) {
+	// Temporarily redirect stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Set a custom version for the test
+	originalVersion := Version
+	Version = "v9.9.9-test"
+	defer func() { Version = originalVersion }()
+
+	// Call the function
+	PrintBanner()
+
+	// Restore stdout
+	w.Close()
+	os.Stdout = oldStdout
+
+	// Read the captured output
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, r)
+	if err != nil {
+		t.Fatalf("Failed to copy from pipe: %v", err)
+	}
+
+	output := buf.String()
+
+	// Verify the output contains the version string
+	if !strings.Contains(output, "v9.9.9-test") {
+		t.Errorf("Expected banner to contain dynamic version 'v9.9.9-test', got:\n%s", output)
+	}
+
+	// Verify the output contains Claritty branding
+	if !strings.Contains(output, "AI-SRE Engine") {
+		t.Errorf("Expected banner to contain 'AI-SRE Engine', got:\n%s", output)
+	}
+}


### PR DESCRIPTION
Fixes #27 

Updated `clarctl-go/internal/ui/ui.go` to use a dynamic Version variable instead of the hardcoded "v1.0"