### PR TITLE
ci: set up automated github pages deployment workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'website/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: website
+
+      - name: Build Docusaurus
+        run: npm run build
+        working-directory: website
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./website/build
+          publish_branch: gh-pages
+          commit_message: "docs: update GitHub Pages [skip ci]"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,6 +8,10 @@ on:
       - 'website/**'
   workflow_dispatch:
 
+concurrency:
+  group: github-pages-deployment
+  cancel-in-progress: false
+
 permissions:
   contents: write
 


### PR DESCRIPTION
## 📖 Description
Resolves #43.

This PR establishes a fully automated, free CI/CD pipeline to deploy the Claritty documentation website to GitHub Pages. It completely eliminates the need for manual `npm run build` and `npm run deploy` commands locally.

## 💡 What Changed
- **Workflow Automation:** Created `.github/workflows/docs.yaml`.
- **Triggers:** The action automatically runs on pushes to `master` if the path is `website`, and can also be triggered manually via `workflow_dispatch`.
- **Pipeline Architecture:**
  - Installs Node.js 20 and caches `npm` dependencies for lightning-fast future builds.
  - Generates the optimized static HTML/JS/CSS assets in `website/build/`.
  - Utilizes `peaceiris/actions-gh-pages@v4` to safely force-push the static assets to the `gh-pages` branch.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated documentation site deployment workflow that publishes the Docusaurus site to the GitHub Pages branch when changes are pushed to the main branch, including manual on-demand deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->